### PR TITLE
Track average and percentiles for latency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,28 +1,32 @@
 buildscript {
-   ext.kotlin_version = '1.0.2'
-   ext.proton_version = '0.13.0'
-   ext.commons_cli_version = '1.3.1'
+    ext.kotlin_version = '1.0.2'
+    ext.proton_version = '0.13.0'
+    ext.commons_cli_version = '1.3.1'
+    ext.commons_math_version = '3.6.1'
+    ext.org_json_version = '20160212'
 
-   repositories {
-     mavenCentral()
-   }
+    repositories {
+        mavenCentral()
+    }
 
-   dependencies {
-     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-   }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
 }
 
 apply plugin: 'kotlin'
 
 repositories {
-  mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
     compile 'org.slf4j:slf4j-api:1.7.13'
 	compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "commons-cli:commons-cli:${commons_cli_version}"
-    compile "org.apache.qpid:proton-j:$proton_version"
+    compile "org.apache.commons:commons-math3:${commons_math_version}"
+    compile "org.apache.qpid:proton-j:${proton_version}"
+    compile "org.json:json:${org_json_version}"
     testCompile 'junit:junit:4.12'
 }
 

--- a/src/main/kotlin/enmasse/perf/Client.kt
+++ b/src/main/kotlin/enmasse/perf/Client.kt
@@ -5,7 +5,8 @@ package enmasse.perf
  */
 class Client(val hostname:String, val port:Int, address:String, msgSize: Int, val duration: Int): Runnable
 {
-    val sender = Sender(address, msgSize)
+    val metricRecorder = MetricRecorder(10, 100000)
+    val sender = Sender(address, msgSize, metricRecorder)
     val recveiver = Receiver(address, msgSize)
     val sendRunner = ClientRunner(hostname, port, sender, duration)
     val recvRunner = ClientRunner(hostname, port, recveiver, duration)
@@ -18,7 +19,7 @@ class Client(val hostname:String, val port:Int, address:String, msgSize: Int, va
     }
 
     fun result(): Result {
-        return recvRunner.result();
+        return metricRecorder.result(sendRunner.currentRuntime())
     }
 }
 

--- a/src/main/kotlin/enmasse/perf/ClientHandler.kt
+++ b/src/main/kotlin/enmasse/perf/ClientHandler.kt
@@ -1,7 +1,3 @@
 package enmasse.perf
 
 import org.apache.qpid.proton.engine.CoreHandler
-
-interface ClientHandler : CoreHandler {
-    fun messageCount(): Long
-}

--- a/src/main/kotlin/enmasse/perf/ClientRunner.kt
+++ b/src/main/kotlin/enmasse/perf/ClientRunner.kt
@@ -2,13 +2,14 @@ package enmasse.perf
 
 import org.apache.qpid.proton.Proton
 import org.apache.qpid.proton.engine.BaseHandler
+import org.apache.qpid.proton.engine.CoreHandler
 import org.apache.qpid.proton.engine.Event
 import java.util.concurrent.TimeUnit
 
 /**
  * @author lulf
  */
-open class ClientRunner(val hostname: String, val port: Int, val clientHandler: ClientHandler, val duration: Int): BaseHandler(), Runnable {
+open class ClientRunner(val hostname: String, val port: Int, val clientHandler: CoreHandler, val duration: Int): BaseHandler(), Runnable {
     private val reactor = Proton.reactor(this)
     private val thr = Thread(this)
     private var endTime = 0L
@@ -45,11 +46,11 @@ open class ClientRunner(val hostname: String, val port: Int, val clientHandler: 
         thr.join()
     }
 
-    fun result(): Result {
+    fun currentRuntime(): Long {
         if (startTime > endTime) {
-            return Result(clientHandler.messageCount(), System.currentTimeMillis() - startTime)
+            return System.currentTimeMillis() - startTime
         } else {
-            return Result(clientHandler.messageCount(), endTime - startTime)
+            return endTime - startTime
         }
     }
 }

--- a/src/main/kotlin/enmasse/perf/Receiver.kt
+++ b/src/main/kotlin/enmasse/perf/Receiver.kt
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicLong
 /**
  * @author lulf
  */
-class Receiver(val address: String, msgSize: Int): BaseHandler(), ClientHandler {
+class Receiver(val address: String, msgSize: Int): BaseHandler() {
 
     val buffer = ByteArray(msgSize)
     var msgsReceived = AtomicLong()
@@ -57,9 +57,5 @@ class Receiver(val address: String, msgSize: Int): BaseHandler(), ClientHandler 
             delivery.settle()
             msgsReceived.incrementAndGet()
         }
-    }
-
-    override fun messageCount(): Long {
-        return msgsReceived.get()
     }
 }

--- a/src/main/kotlin/enmasse/perf/Result.kt
+++ b/src/main/kotlin/enmasse/perf/Result.kt
@@ -1,7 +1,131 @@
 package enmasse.perf
 
-data class Result(val numMessages: Long, val duration: Long) {
+import org.json.JSONObject
+import java.util.concurrent.TimeUnit
+
+
+data class Result(val numMessages: Long, val duration: Long, val totalLatency: Long, val buckets: Array<Bucket>) {
     fun throughput(): Long {
         return numMessages / (duration / 1000)
+    }
+
+    fun averageLatency(): Double {
+        return totalLatency / numMessages.toDouble()
+    }
+
+    fun percentile(p: Double): LongRange {
+        var entriesToCount = (numMessages * p).toLong()
+        for (bucket in buckets) {
+            entriesToCount -= bucket.count()
+            if (entriesToCount <= 0) {
+                return bucket.range
+            }
+        }
+        throw IllegalStateException("Was never able to count required entries with p = ${p}")
+    }
+
+}
+
+interface ResultFormatter {
+    fun asString(result: Result): String
+}
+
+class DefaultResultFormatter: ResultFormatter {
+    override fun asString(result: Result): String {
+        val sb = StringBuilder()
+        sb.appendln("Result:")
+        sb.appendln("Duration:\t\t${result.duration / 1000} s")
+        sb.appendln("Messages:\t\t${result.numMessages}")
+        sb.appendln("Throughput:\t\t${result.throughput()} msgs/s")
+        sb.appendln("Latency avg:\t\t${result.averageLatency()} us")
+        sb.appendln("Latency 50p:\t\t${result.percentile(0.5)} us")
+        sb.appendln("Latency 75p:\t\t${result.percentile(0.75)} us")
+        sb.appendln("Latency 90p:\t\t${result.percentile(0.9)} us")
+        sb.appendln("Latency 95p:\t\t${result.percentile(0.95)} us")
+        return sb.toString()
+     }
+}
+
+class JSONResultFormatter: ResultFormatter {
+    override fun asString(result: Result): String {
+        val json = JSONObject()
+        json.put("duration", result.duration / 1000)
+        json.put("messages", result.numMessages)
+        json.put("throughput", result.throughput())
+        json.put("avg", result.averageLatency())
+        json.put("50p", result.percentile(0.5))
+        json.put("75p", result.percentile(0.75))
+        json.put("90p", result.percentile(0.9))
+        json.put("95p", result.percentile(0.95))
+        return json.toString(0)
+    }
+
+}
+
+fun mergeResults(a: Result, b: Result): Result {
+
+    return Result(a.numMessages + b.numMessages, Math.max(a.duration, b.duration), a.totalLatency + b.totalLatency, mergeBuckets(a.buckets, b.buckets))
+}
+
+fun mergeBuckets(a: Array<Bucket>, b: Array<Bucket>): Array<Bucket> {
+    return if (a.size == 0) {
+        b
+    } else if (b.size == 0) {
+        a
+    } else {
+        a.forEachIndexed { i, bucket ->
+            bucket.increment(b.get(i).count())
+        }
+        a
+    }
+}
+
+class MetricRecorder(bucketStep: Long, numBuckets: Long) {
+    @Volatile private var totalLatency = 0L
+    @Volatile private var numMessages= 0L
+    private val buckets: Array<Bucket>
+    init {
+        buckets = listOf(0.rangeTo(numBuckets - 1).map { i ->
+            val start = i * bucketStep
+            val end = start + bucketStep
+            Bucket(start.rangeTo(end))
+        }, listOf(Bucket((bucketStep * numBuckets).rangeTo(Long.MAX_VALUE)))).flatten().toTypedArray()
+    }
+
+    fun record(latencyInNanos: Long) {
+        val latency = TimeUnit.NANOSECONDS.toMicros(latencyInNanos)
+        numMessages++
+        totalLatency += latency
+        for (bucket in buckets) {
+            if (bucket.range.contains(latency)) {
+                bucket.increment()
+                break
+            }
+        }
+    }
+
+    fun result(duration: Long): Result {
+        return Result(numMessages, duration, totalLatency, buckets)
+    }
+}
+
+class Bucket(val range: LongRange, val initialCount: Long = 0L)
+{
+    private var count = initialCount
+    fun increment(inc: Long = 1L) {
+        count += inc
+    }
+
+    fun count(): Long {
+        return count
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (other is Bucket) {
+            if (other.range == this.range) {
+                return true
+            }
+        }
+        return false
     }
 }


### PR DESCRIPTION
- Support different output formats, a default human readable and JSON
- Estimate percentiles using fixed size buckets, and count occurences within each bucket.
